### PR TITLE
Fixes "Too many open files"

### DIFF
--- a/src/LDX/VoteReward/Main.php
+++ b/src/LDX/VoteReward/Main.php
@@ -10,11 +10,8 @@ use pocketmine\item\Item;
 class Main extends PluginBase {
   private $items, $commands, $key, $url;
   public function onEnable() {
-    if(!file_exists($this->getDataFolder() . "config.yml")) {
-      @mkdir($this->getDataFolder());
-      file_put_contents($this->getDataFolder() . "config.yml",$this->getResource("config.yml"));
-    }
-    $c = yaml_parse(file_get_contents($this->getDataFolder() . "config.yml"));
+    $this->saveDefaultConfig();
+    $c = $this->getConfig()->getAll();
     $num = 0;
     $this->key = $c["API-Key"];
     $this->url = $c["Vote-URL"];


### PR DESCRIPTION
This fixes issues with not closing resources given by PocketMine, causing a crash at a later stage.
Users usually blame PocketMine for this, but it's entirely a plugin's fault.

This code was found via GitHub search, please review your code for usage of:

* `Plugin->getResource()` without `fclose()` calls later
* Not needed `Plugin->getResource()` calls
* `fopen()` calls without `fclose()`
* `popen()` calls without `pclose()`